### PR TITLE
Fix unaccounted for RPM-dependency

### DIFF
--- a/yum-cron/yum-cron.sls
+++ b/yum-cron/yum-cron.sls
@@ -21,6 +21,7 @@ pkg_support:
     - pkgs:
       - postfix
       - cyrus-sasl-plain
+      - mailx
 
 # Need this to automate runing of cron update-availability detection
 pkg_yum-cron:


### PR DESCRIPTION
Yum-cron needs `mailx` package, even though `yum-cron` RPM doesn't enumerate/resolve the dependency